### PR TITLE
ci: try ubuntu bionic for TRAVIS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 arch: arm64
+dist: bionic
 language: c
 compiler: gcc
 services:


### PR DESCRIPTION
on `xenial` I got failure when compiling SPDK on `rootdir=$(readlink -f "$specdir/../")` due to permissions. 
Maybe something with kernel... ?
update to `bionic` seems like resolving this